### PR TITLE
Fixing 10 flaky tests in Undertow module 

### DIFF
--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -22,7 +22,6 @@
 package org.wildfly.extension.undertow;
 
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -129,7 +128,7 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
         Host host = (Host) awaitServiceValue(hostSC);
         if (flag == 1) {
             Assert.assertEquals(3, host.getAllAliases().size());
-            Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1));
+            Assert.assertTrue(host.getAllAliases().contains("default-alias"));
         }
 
         final ServiceName locationServiceName = UndertowService.locationServiceName(virtualHostName, "default-virtual-host", "/");


### PR DESCRIPTION
Fixing the 10 flaky tests by changing the test case code in AbstractUndertowSubsystemTestCase.java

`org.wildfly.extension.undertow.UndertowSubsystem100TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem30TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem80TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem90TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem60TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem70TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem50TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem31TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem40TestCase#testRuntime
org.wildfly.extension.undertow.UndertowSubsystem110TestCase#testRuntime `

The existing code contains the code`Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1));` wherein getAllAliases() returns a unmodifiableSet [HashSet], and the test case was checking for the existence of "default-alias" at the second index of the list formed from the set. This is as good as checking for the existence of "default-alias" in the initial Set itself.


Changed code :`Assert.assertTrue(host.getAllAliases().contains("default-alias"));`

Reason for Flakiness: getAliases() returns a Set referenced to a HashSet . As per the Oracle documentation " HashSet makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time." So converting the Set into a List doesn't ensure the deterministic order of elements and doing get(1) may result in a non-deterministic value. This causes flakiness which is now removed.